### PR TITLE
New feature: readsegy user interface in shell script

### DIFF
--- a/01_import_segy.sh
+++ b/01_import_segy.sh
@@ -2,7 +2,7 @@
 # Examples of segyread and segywrite
 # Author    : John Stockwell
 # Modify by : Felipe Timoteo
-set -x
+
 #####
 ##
 ## processing steps:

--- a/02_selectshots_savesegy.sh
+++ b/02_selectshots_savesegy.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 # Examples of suwind and segywrite
 # Author: Felipe Timóteo
-set -x
+
 ##
 ## processing steps:
 ##	1) read seismic unix data and show input data (optional)

--- a/03_sort.sh
+++ b/03_sort.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 # Examples of sort
 # Author    : Felipe Timoteo
-set -x
+
 #####
 ##
 ## processing steps:

--- a/readsegy
+++ b/readsegy
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# readsegy (Shell Script)
+# 
+# Purpose: User interface to call shell script readsegy programs.
+# 
+# Site: http://www.dirackslounge.online
+# 
+# Version 1.0
+# 
+# Programer: Rodolfo Dirack 23/02/2020
+# 
+# Email: rodolfo_profissional@hotmail.com
+# 
+# License: GPL-3.0 <https://www.gnu.org/licenses/gpl-3.0.txt>.

--- a/readsegy
+++ b/readsegy
@@ -53,4 +53,43 @@ PARAMETERS="-h --help Display help and exit
 -s --select Select Shots
 -o --sort Trace Sorting"
 
+case "$1" in
 
+	-h | --help)
+
+		clear
+		echo -e "\n$PROGRAM\n"
+		echo -e "$DESCRIPTION\n"
+		echo -e "$PARAMETERS\n"
+		exit 0
+		;;
+
+	-v | --version)
+		
+		echo "$(basename "$0") $VERSION"
+		exit 0
+		;;
+
+	-i | --import) # Import segy data
+
+			./01_import_segy.sh
+		;;
+		
+	-s | --select) # Select Shots
+
+			./02_selectshots_savesegy.sh
+		;;
+
+	-o | --sort) # Trace Sorting
+
+			./03_sort.sh
+		;;
+
+	*)
+
+		echo -e "Option $1 is unknown!\nType $0 -h to get help."
+		exit 1
+		;;
+esac
+
+exit 0

--- a/readsegy
+++ b/readsegy
@@ -14,6 +14,9 @@
 # 
 # License: GPL-3.0 <https://www.gnu.org/licenses/gpl-3.0.txt>.
 
+# Program version
+VERSION="1.0"
+
 # Debug option (Only for programers)
 # Use DEBUG=1 to run program in debug mode
 DEBUG=0

--- a/readsegy
+++ b/readsegy
@@ -44,5 +44,13 @@ SORT_SCRIPT="03_sort.sh"
 	exit 1
 }
 
+# Help mesage
+PROGRAM="$(basename $0) [ -h | -v | -i | -s | -o ]"
+DESCRIPTION="Script to manipulate segy files using seismic unix"
+PARAMETERS="-h --help Display help and exit
+-v --version Display program version and exit
+-i --import Import segy data
+-s --select Select Shots
+-o --sort Trace Sorting"
 
 

--- a/readsegy
+++ b/readsegy
@@ -24,4 +24,14 @@ DEBUG=0
 
 }
 
+# Check for the shell scripts dependencies
+IMPORT_SCRIPT="01_import_segy.sh"
+SELECT_SHOTS_SCRIPT="02_selectshots_savesegy.sh"
+SORT_SCRIPT="03_sort.sh"
+[ -f "$IMPORT_SCRIPT" -a -f "$SELECT_SHOTS_SCRIPT" -a -f "$SORT_SCRIPT" ] || {
+	echo "Some program dependencies not found in this repository!"
+	exit 1
+}
+
+
 

--- a/readsegy
+++ b/readsegy
@@ -31,8 +31,16 @@ DEBUG=0
 IMPORT_SCRIPT="01_import_segy.sh"
 SELECT_SHOTS_SCRIPT="02_selectshots_savesegy.sh"
 SORT_SCRIPT="03_sort.sh"
+
 [ -f "$IMPORT_SCRIPT" -a -f "$SELECT_SHOTS_SCRIPT" -a -f "$SORT_SCRIPT" ] || {
 	echo "Some program dependencies not found in this repository!"
+	exit 1
+}
+
+# Force user to choose an option
+[ -z "$1" ] && {
+	echo "You should choose an option"
+	echo "type $(basename $0) -h to get help"
 	exit 1
 }
 

--- a/readsegy
+++ b/readsegy
@@ -13,3 +13,15 @@
 # Email: rodolfo_profissional@hotmail.com
 # 
 # License: GPL-3.0 <https://www.gnu.org/licenses/gpl-3.0.txt>.
+
+# Debug option (Only for programers)
+# Use DEBUG=1 to run program in debug mode
+DEBUG=0
+
+[ "$DEBUG" -eq "1" ] && {
+
+	set -xv
+
+}
+
+


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Description**

Hello,
I've done the _readsegy_ Shell Script interface in order to help users to call this repository programs. 

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Context and images (if needed)**

The idea is simply to call the script programs by calling _readsegy_ as a shell command with a flag option.
Example, in order to get help, type:

```shell
~$  ./readsegy -h
```

And it'll show the program's help. It should look like that:

```
readsegy [ -h | -v | -i | -s | -o ]

Script to manipulate segy files using seismic unix

-h --help Display help and exit
-v --version Display program version and exit
-i --import Import segy data
-s --select Select Shots
-o --sort Trace Sorting
```

The '-v' option shows program's version stored in VERSION variable:

```
readsegy 1.0
```

And a list of other options bellow: 

- **-i** option calls _01\_import\_segy.sh_ script
- **-s** option calls _02\_selectshots\_savesegy.sh_ script
- **-o** option calls _03\_sort.sh_ script

And you have a debug option [in this part](https://github.com/fetim/ReadSegy/pull/1/commits/16ff3b0768954ba4d06df2b28bbcae01d4cb63b8#r384659422) of readsegy script (Only for programers):

```sh
DEBUG=1

[ "$DEBUG" -eq "1" ] && {

        set -xv

}

```
Choosing DEBUG=1 enables the 'debug mode' of the program.
It runs the script with the _set -xv_ bash option enabled.


>Please contact me if you have any doubt or request.

>thanks,

>Rodolfo Dirack